### PR TITLE
Upgrade OKHttp dependency

### DIFF
--- a/elb/pom.xml
+++ b/elb/pom.xml
@@ -110,7 +110,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
       <exclusions>

--- a/elb/pom.xml
+++ b/elb/pom.xml
@@ -113,13 +113,6 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!-- Already provided by jclouds-sshj -->
-        <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/elb/src/test/java/org/jclouds/elb/internal/BaseELBApiMockTest.java
+++ b/elb/src/test/java/org/jclouds/elb/internal/BaseELBApiMockTest.java
@@ -34,9 +34,9 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.inject.Module;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 public class BaseELBApiMockTest {
 
@@ -52,7 +52,7 @@ public class BaseELBApiMockTest {
     @BeforeMethod
     public void start() throws IOException {
         server = new MockWebServer();
-        server.play();
+        server.start();
         api = ContextBuilder.newBuilder("elb")
                 .credentials("", MOCK_BEARER_TOKEN)
                 .endpoint(url(""))
@@ -72,7 +72,7 @@ public class BaseELBApiMockTest {
     }
 
     protected String url(String path) {
-        return server.getUrl(path).toString();
+        return server.url(path).toString();
     }
 
     protected MockResponse xmlResponse(String resource) {

--- a/glacier/pom.xml
+++ b/glacier/pom.xml
@@ -109,7 +109,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/glacier/src/test/java/org/jclouds/glacier/blobstore/strategy/internal/MultipartUploadStrategyMockTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/blobstore/strategy/internal/MultipartUploadStrategyMockTest.java
@@ -48,9 +48,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashCode;
 import com.google.common.net.HttpHeaders;
 import com.google.inject.Module;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 @Test(groups = {"mock"}, singleThreaded = true)
 public class MultipartUploadStrategyMockTest {
@@ -75,8 +75,8 @@ public class MultipartUploadStrategyMockTest {
    @BeforeMethod
    private void initServer() throws IOException {
       server = new MockWebServer();
-      server.play();
-      client = getGlacierClient(server.getUrl("/"));
+      server.start();
+      client = getGlacierClient(server.url("/").url());
    }
 
    @AfterMethod


### PR DESCRIPTION
The JClouds project module upgrades the okhttp server library and related dependencies such as mockwebserver from 2.2.0 to 3.14.9. The vendor switched the groupId declaration from com.squareup.okhttp to com.squareup.okhttp3.

Adjust imports and api calls for newer okhttp vers